### PR TITLE
Fix key-name for open-cmd

### DIFF
--- a/nerdtree_plugin/vim-nerdtree-dir-enter.vim
+++ b/nerdtree_plugin/vim-nerdtree-dir-enter.vim
@@ -1,4 +1,4 @@
 function! NERDTreeCustomOpenDir(node)
 	call a:node.activate()
 endfunction
-call NERDTreeAddKeyMap({'key': '<Enter>', 'scope': 'DirNode', 'callback': 'NERDTreeCustomOpenDir', 'quickhelpText': 'open dir'})
+call NERDTreeAddKeyMap({'key': '<ENTER>', 'scope': 'DirNode', 'callback': 'NERDTreeCustomOpenDir', 'quickhelpText': 'open dir'})


### PR DESCRIPTION
The wrong key name prevents files from being opened in nerdtree.
Changing this to an all-caps string seems to fix the issue.

Fixes #1.
